### PR TITLE
Set slider granularity to 6h for datetime fields

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6252175'
+ValidationKey: '6449280'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -6,3 +6,5 @@ AcceptedWarnings:
 AcceptedNotes: ~
 allowLinterWarnings: yes
 enforceVersionUpdate: no
+AutocreateCITATION: yes
+skipCoverage: no

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,14 +23,14 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            any::lucode2
-            any::covr
-            any::madrat
-            any::magclass
-            any::citation
-            any::gms
-            any::goxygen
-            any::GDPuc
+            lucode2
+            covr
+            madrat
+            magclass
+            citation
+            gms
+            goxygen
+            GDPuc
           # piam packages also available on CRAN (madrat, magclass, citation,
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
@@ -43,6 +43,13 @@ jobs:
         run: |
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
+
+      - name: Run pre-commit checks
+        shell: bash
+        run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+          pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key
         shell: Rscript {0}
@@ -63,6 +70,6 @@ jobs:
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
+    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc
@@ -25,4 +25,4 @@ repos:
     -   id: readme-rmd-rendered
     -   id: use-tidy-description
 ci:
-    autoupdate_schedule: quarterly
+    autoupdate_schedule: weekly

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   shinyresults: A collection of shiny apps and modules to visualize/handle model
       results
-version: 0.31.3
-date-released: '2024-09-09'
+version: 0.32.0
+date-released: '2025-03-07'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: shinyresults
 Title: A collection of shiny apps and modules to visualize/handle model
     results
-Version: 0.31.3
-Date: 2024-09-09
+Version: 0.32.0
+Date: 2025-03-07
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/modFilter.R
+++ b/R/modFilter.R
@@ -128,6 +128,7 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
           max = max,
           value = value,
           ticks = FALSE,
+          step = 6*3600,
           timeFormat = "%F %H:%M"
         )
       ))

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # A collection of shiny apps and modules to visualize/handle model
     results
 
-R package **shinyresults**, version **0.31.3**
+R package **shinyresults**, version **0.32.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/shinyresults)](https://cran.r-project.org/package=shinyresults) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1478922.svg)](https://doi.org/10.5281/zenodo.1478922) [![R build status](https://github.com/pik-piam/shinyresults/workflows/check/badge.svg)](https://github.com/pik-piam/shinyresults/actions) [![codecov](https://codecov.io/gh/pik-piam/shinyresults/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/shinyresults) [![r-universe](https://pik-piam.r-universe.dev/badges/shinyresults)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,18 +40,19 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **shinyresults** in publications use:
 
-Dietrich J, Humpenoeder F, Sauer P (2024). _shinyresults: A collection of shiny apps and modules to visualize/handle model results_. doi:10.5281/zenodo.1478922 <https://doi.org/10.5281/zenodo.1478922>, R package version 0.31.3, <https://github.com/pik-piam/shinyresults>.
+Dietrich J, Humpenoeder F, Sauer P (2025). "shinyresults: A collection of shiny apps and modules to visualize/handle model results." doi:10.5281/zenodo.1478922 <https://doi.org/10.5281/zenodo.1478922>, Version: 0.32.0, <https://github.com/pik-piam/shinyresults>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
-@Manual{,
+@Misc{,
   title = {shinyresults: A collection of shiny apps and modules to visualize/handle model
-results},
+    results},
   author = {Jan Philipp Dietrich and Florian Humpenoeder and Pascal Sauer},
-  year = {2024},
-  note = {R package version 0.31.3},
-  url = {https://github.com/pik-piam/shinyresults},
   doi = {10.5281/zenodo.1478922},
+  date = {2025-03-07},
+  year = {2025},
+  url = {https://github.com/pik-piam/shinyresults},
+  note = {Version: 0.32.0},
 }
 ```


### PR DESCRIPTION
This increases the granularity of the slider on run selection (and other datetime sliderInput items like revision date), from the previous automatically chosen value of ~1 month (seems to be 1% of the total time span). Primary reason is to be able to preselect all scenarios of a single run without results of the previous or next day, which requires a somewhat below 1 day resolution. The exaxt value can be changed easily as it is just a fixed amount in seconds if we e.g. want to choose 12h or 24h instead.

Note: I'm unsure whether "minor revision" version increase is the right level for this, as it is a minimal change in appearance and not a new feature.