### PR TITLE
Bugfix: sanitizeAreaPlot should only be applied when calling it with renderPlotly

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6656760'
+ValidationKey: '6677263'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   shinyresults: A collection of shiny apps and modules to visualize/handle model
       results
-version: 0.33.0
-date-released: '2025-03-25'
+version: 0.33.1
+date-released: '2025-03-26'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: shinyresults
 Title: A collection of shiny apps and modules to visualize/handle model
     results
-Version: 0.33.0
-Date: 2025-03-25
+Version: 0.33.1
+Date: 2025-03-26
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/modAreaPlot.R
+++ b/R/modAreaPlot.R
@@ -55,9 +55,9 @@ modAreaPlot <- function(input, output, session, report) {
           annotate("text", x=1, y=1, label= "Too many data points (>5000)! Please filter data!") +
           theme_void()
       } else {
-        p <- suppressMessages(sanitizeAreaPlot(mipArea(x = selection()$x, 
-                                                       transpose = input$transpose_grid) 
-                                               + mip::theme_mip(size=10)))
+        p <- suppressMessages(mipArea(x = selection()$x,
+                                      transpose = input$transpose_grid)
+                              + mip::theme_mip(size=10))
       }
     } else p <- NULL
     message("done! (",round(as.numeric(Sys.time()-start,units="secs"),2),"s)")
@@ -100,7 +100,7 @@ modAreaPlot <- function(input, output, session, report) {
   )
   
   return(renderPlotly({
-    ggplotly(areaplot())}))
+    sanitizeAreaPlot(areaplot())}))
 
   # return(renderCachedPlot(areaplot(), res = 120,
   #                         cacheKeyExpr = { list(selection(), input$transpose_grid, input$plus_size) }))

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # A collection of shiny apps and modules to visualize/handle model
     results
 
-R package **shinyresults**, version **0.33.0**
+R package **shinyresults**, version **0.33.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/shinyresults)](https://cran.r-project.org/package=shinyresults) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1478922.svg)](https://doi.org/10.5281/zenodo.1478922) [![R build status](https://github.com/pik-piam/shinyresults/workflows/check/badge.svg)](https://github.com/pik-piam/shinyresults/actions) [![codecov](https://codecov.io/gh/pik-piam/shinyresults/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/shinyresults) [![r-universe](https://pik-piam.r-universe.dev/badges/shinyresults)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **shinyresults** in publications use:
 
-Dietrich J, Humpenoeder F, Sauer P (2025). "shinyresults: A collection of shiny apps and modules to visualize/handle model results." doi:10.5281/zenodo.1478922 <https://doi.org/10.5281/zenodo.1478922>, Version: 0.33.0, <https://github.com/pik-piam/shinyresults>.
+Dietrich J, Humpenoeder F, Sauer P (2025). "shinyresults: A collection of shiny apps and modules to visualize/handle model results." doi:10.5281/zenodo.1478922 <https://doi.org/10.5281/zenodo.1478922>, Version: 0.33.1, <https://github.com/pik-piam/shinyresults>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,9 +50,9 @@ A BibTeX entry for LaTeX users is
     results},
   author = {Jan Philipp Dietrich and Florian Humpenoeder and Pascal Sauer},
   doi = {10.5281/zenodo.1478922},
-  date = {2025-03-25},
+  date = {2025-03-26},
   year = {2025},
   url = {https://github.com/pik-piam/shinyresults},
-  note = {Version: 0.33.0},
+  note = {Version: 0.33.1},
 }
 ```


### PR DESCRIPTION
#13 accidentally applied the area plot sanitization (removing duplicate menu entries) at the wrong level, as the legend item duplication is only introduced by `ggplotly(areaPlot())` when rendering the plot, and the download buttons were fine.