### PR TITLE
Enable multiple region select

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7185850'
+ValidationKey: '7395480'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   shinyresults: A collection of shiny apps and modules to visualize/handle model
       results
-version: 0.35.0
-date-released: '2026-03-19'
+version: 0.36.0
+date-released: '2026-03-31'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: shinyresults
 Title: A collection of shiny apps and modules to visualize/handle model
     results
-Version: 0.35.0
-Date: 2026-03-19
+Version: 0.36.0
+Date: 2026-03-31
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/appResults.R
+++ b/R/appResults.R
@@ -21,6 +21,9 @@
 #'                      multiple validation files.
 #'            username - username to access "file" and "resultsfolder".
 #'            password - password to access "file" and "resultsfolder".
+#'            selectionSets - named list of selection sets per filter column.
+#'                   Each element is a named list mapping set labels to character vectors of values.
+#'                   Example: \code{list(region = list("All EUR regions" = c("EUC", "EUS", "EUW", "DEU")))}
 #' @param readFilePar read report data files in parallel (faster) (TRUE) or in sequence (FALSE)
 #' @param variableConfig Path to a YAML configuration file with variable presets, or NULL to use
 #'                       default config. The config defines presets for the Dashboard tab and

--- a/R/modAreaPlot.R
+++ b/R/modAreaPlot.R
@@ -68,41 +68,12 @@ modAreaPlot <- function(input, output, session, report,
     return(p)
   })
   
-  createFilename <- function(variable,ending) {
-    tmp <- shorten_legend(variable, identical_only = TRUE)
-    out <- sub("_+$","",gsub("\\.+","_",make.names(attr(tmp, "front"))))
-    out <- paste0(out,".",ending)
-    return(out)
-  }
-  
-  output$downloadPlotPDF <- downloadHandler(
-    filename = reactive(createFilename(selection()$x$variable,"pdf")),
-    content = function(file) {
-      ggsave(file, plot = areaplot(), device = "pdf",scale=1,width=20,height=18,units="cm",dpi=150)
-    }
-  )
-  
-  output$downloadPlotPNG <- downloadHandler(
-    filename = reactive(createFilename(selection()$x$variable,"png")),
-    content = function(file) {
-      ggsave(file, plot = areaplot(), device = "png",scale=1,width=20,height=18,units="cm",dpi=150)
-    }
-  )
-  
-  output$downloadPlotEPS <- downloadHandler(
-    filename = reactive(createFilename(selection()$x$variable,"eps")),
-    content = function(file) {
-      ggsave(file, plot = areaplot(), device = "eps",scale=1,width=20,height=18,units="cm",dpi=150)
-    }
-  )
-  
-  output$downloadPlotRDS <- downloadHandler(
-    filename = reactive(createFilename(selection()$x$variable,"rds")),
-    content = function(file) {
-      saveRDS(areaplot(),file=file)
-    }
-  )
-  
+  baseFilename <- reactive({
+    tmp <- shorten_legend(selection()$x$variable, identical_only = TRUE)
+    sub("_+$", "", gsub("\\.+", "_", make.names(attr(tmp, "front"))))
+  })
+  plotDownloadHandlers(output, areaplot, baseFilename)
+
   return(renderPlotly({
     sanitizeAreaPlot(areaplot())}))
 

--- a/R/modAreaPlot.R
+++ b/R/modAreaPlot.R
@@ -12,8 +12,8 @@
 #' @export
 
 modAreaPlot <- function(input, output, session, report,
-                       selectionSets = getOption("appResults")[[1]]$selectionSets) {
-  
+                        selectionSets = getOption("appResults")[[1]]$selectionSets) {
+
   addGroup <- function(report) {
     start <- Sys.time()
     if(is.null(report)) return(NULL)
@@ -40,7 +40,7 @@ modAreaPlot <- function(input, output, session, report,
     }
     return(gp)
   }
-  
+
   selection <- callModule(modFilter, "runfilter",
                           data         = reactive(addGroup(report$report())), 
                           exclude      = c("variable","value","unit"), 
@@ -67,7 +67,7 @@ modAreaPlot <- function(input, output, session, report,
     message("done! (",round(as.numeric(Sys.time()-start,units="secs"),2),"s)")
     return(p)
   })
-  
+
   baseFilename <- reactive({
     tmp <- shorten_legend(selection()$x$variable, identical_only = TRUE)
     sub("_+$", "", gsub("\\.+", "_", make.names(attr(tmp, "front"))))
@@ -79,5 +79,4 @@ modAreaPlot <- function(input, output, session, report,
 
   # return(renderCachedPlot(areaplot(), res = 120,
   #                         cacheKeyExpr = { list(selection(), input$transpose_grid, input$plus_size) }))
-  
 }

--- a/R/modAreaPlot.R
+++ b/R/modAreaPlot.R
@@ -4,12 +4,15 @@
 #'
 #' @param input,output,session Default input, output and session objects coming from shiny
 #' @param report A reactive containing the report to be visualized
+#' @param selectionSets named list of selection sets per filter column (passed to \code{\link{modFilter}}).
+#' Defaults to the \code{selectionSets} entry of the active \code{appResults} option.
 #' @author Jan Philipp Dietrich, Florian Humpenoeder
 #' @seealso \code{\link{modAreaPlotUI}}, \code{\link{appResults}}
 #' @importFrom data.table as.data.table merge.data.table
 #' @export
 
-modAreaPlot <- function(input, output, session, report) {
+modAreaPlot <- function(input, output, session, report,
+                       selectionSets = getOption("appResults")[[1]]$selectionSets) {
   
   addGroup <- function(report) {
     start <- Sys.time()
@@ -44,7 +47,8 @@ modAreaPlot <- function(input, output, session, report) {
                           showAll      = TRUE, 
                           multiple     = c(group=FALSE),
                           order        = c("group"),
-                          name         = sub("-$","",session$ns('')))
+                          name         = sub("-$","",session$ns('')),
+                          selectionSets = selectionSets)
 
   areaplot <- reactive({
     start <- Sys.time()

--- a/R/modFilter.R
+++ b/R/modFilter.R
@@ -17,6 +17,10 @@
 #' @param name name used to identify the filter in the log
 #' @param preselectYear if provided the year filter will be preselected with this value
 #' @param preselectMinDate if provided the date filter will be preselected with this as lower value
+#' @param selectionSets named list of selection sets per filter column. Each element is a named list
+#' mapping set labels to character vectors of values. When a set is selected, all its member values
+#' are added to the selection. Only sets where all members are present in the data are shown.
+#' Example: \code{list(region = list("All EUR regions" = c("EUC", "EUS", "EUW", "DEU")))}
 #' @return  a reactive list with x as the filtered data and xdata containing the list of additional,
 #' filtered data element.
 #' @author Jan Philipp Dietrich
@@ -28,7 +32,8 @@
 modFilter <- function(input, # nolint: cyclocomp_linter.
                       output, session, data, exclude = NULL, showAll = FALSE,
                       multiple = NULL, xdata = NULL, xdataExclude = NULL, order = NULL,
-                      name = NULL, preselectYear = NULL, preselectMinDate = NULL) {
+                      name = NULL, preselectYear = NULL, preselectMinDate = NULL,
+                      selectionSets = NULL) {
 
   if (!is.null(name)) name <- paste0(".:|", name, "|:. ")
 
@@ -37,6 +42,28 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
   x <- reactiveValues()
   x$initialized <- FALSE
   x$activefilter <- NULL
+
+  # Build grouped choices for selectize dropdown, adding selection sets as an optgroup
+  augmentChoices <- function(choices, filter, selectionSets) {
+    sets <- selectionSets[[filter]]
+    if (is.null(sets)) return(choices)
+    # Only include sets where ALL members are present in current choices
+    validSets <- Filter(function(members) all(members %in% choices), sets)
+    if (length(validSets) == 0) return(choices)
+    setChoices <- stats::setNames(paste0("__SET__", names(validSets)), names(validSets))
+    structure(list(Values = choices, "Selection Sets" = setChoices), class = "list")
+  }
+
+  # Expand __SET__ entries in a selection to their member values
+  expandSets <- function(selected, filter, selectionSets) {
+    sets <- selectionSets[[filter]]
+    if (is.null(sets) || is.null(selected)) return(selected)
+    isSet <- grepl("^__SET__", selected)
+    if (!any(isSet)) return(selected)
+    setNames <- sub("^__SET__", "", selected[isSet])
+    expanded <- unlist(sets[setNames], use.names = FALSE)
+    unique(c(selected[!isSet], expanded))
+  }
 
   selectdata <- function(data, input, filter, xdata, xdataExclude) {
     start <- Sys.time()
@@ -84,12 +111,16 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
         if (!is.null(input[[sf]])) {
           # Get unique sorted choices, dropping unused factor levels
           slchoices <- sort(unique(as.character(data[[f]])))
-          # Compute valid selection (intersection of current selection and available choices)
-          validSelected <- intersect(input[[sf]], slchoices)
+          # Expand any selection set entries to their member values
+          rawSelected <- expandSets(input[[sf]], f, selectionSets)
+          # Compute valid selection (intersection of expanded selection and available choices)
+          validSelected <- intersect(rawSelected, slchoices)
           if (length(validSelected) == 0) validSelected <- NULL
-          # Update UI if there are choices and they've changed
-          if (length(slchoices) > 0 && !setequal(slchoices, x[[sf]])) {
-            updateSelectizeInput(session, sf, choices = slchoices, selected = validSelected)
+          # Update UI if there are choices, sets were expanded, or choices changed
+          setsExpanded <- any(grepl("^__SET__", input[[sf]]))
+          if (length(slchoices) > 0 && (setsExpanded || !setequal(slchoices, x[[sf]]))) {
+            augmented <- augmentChoices(slchoices, f, selectionSets)
+            updateSelectizeInput(session, sf, choices = augmented, selected = validSelected)
             x[[sf]] <- slchoices
           }
           tmp2 <- function(data, f, selection) {
@@ -116,7 +147,8 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
     return(out)
   }
 
-  selectUI <- function(session, filter, data, class, multiple, preselectYear, preselectMinDate) {
+  selectUI <- function(session, filter, data, class, multiple, preselectYear, preselectMinDate,
+                       selectionSets = NULL) {
     if (filter == "") {
       return(NULL)
     }
@@ -170,6 +202,7 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
       } else {
         selected <- NULL
       }
+      augmented <- augmentChoices(choices, filter, selectionSets)
       # Suppress warning about large number of options - we use maxOptions to handle this
       return(tags$div(
         id = session$ns(paste0("div", filter)),
@@ -177,7 +210,7 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
           selectizeInput(
             inputId = session$ns(id),
             label = filter,
-            choices = choices,
+            choices = augmented,
             selected = selected,
             multiple = multiple,
             options = list(maxOptions = 5000, maxItems = if (multiple) 1000 else 1)
@@ -188,7 +221,8 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
   }
 
 
-  initialize <- function(input, session, data, x, exclude, order, multiple, showAll, preselectYear, preselectMinDate) {
+  initialize <- function(input, session, data, x, exclude, order, multiple, showAll, preselectYear, preselectMinDate,
+                         selectionSets) {
 
     if (!is.null(data())) {
       start <- Sys.time()
@@ -229,7 +263,7 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
         removeUI(selector = paste0("#", session$ns("filterselector")))
         tmpfunc <- function(xf, x) {
           return(selectUI(session, xf, x$data[[xf]], x$filterclass[xf], x$filtermultiple[xf],
-                          preselectYear, preselectMinDate))
+                          preselectYear, preselectMinDate, selectionSets))
         }
         uiList <- lapply(x$filter, tmpfunc, x)
         output$moreFilters <- renderUI(tagList(uiList))
@@ -241,7 +275,7 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
             selector = paste0("#", session$ns("filterend")),
             where = "beforeBegin",
             ui = selectUI(session, "year", x$data[["year"]],  x$filterclass["year"], x$filtermultiple["year"],
-                          preselectYear, preselectMinDate)
+                          preselectYear, preselectMinDate, selectionSets)
           )
 
           x$activefilter <- c(x$activefilter, c("year"))
@@ -251,7 +285,7 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
             selector = paste0("#", session$ns("filterend")),
             where = "beforeBegin",
             ui = selectUI(session, input$filter, x$data[[input$filter]], x$filterclass[input$filter],
-                          x$filtermultiple[input$filter], preselectYear, preselectMinDate)
+                          x$filtermultiple[input$filter], preselectYear, preselectMinDate, selectionSets)
           )
           x$activefilter <- c(x$activefilter, input$filter)
         }
@@ -261,13 +295,13 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
     }
   }
 
-  updatefilter <- function(input, x, preselectYear, preselectMinDate) {
+  updatefilter <- function(input, x, preselectYear, preselectMinDate, selectionSets) {
     if (!(input$filter %in% x$activefilter)) {
       insertUI(
         selector = paste0("#", session$ns("filterend")),
         where = "beforeBegin",
         ui = selectUI(session, input$filter, x$out$x[[input$filter]], x$filterclass[input$filter],
-                      x$filtermultiple[input$filter], preselectYear, preselectMinDate)
+                      x$filtermultiple[input$filter], preselectYear, preselectMinDate, selectionSets)
       )
       x$activefilter <- c(x$activefilter, input$filter)
     }
@@ -291,14 +325,15 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
 
 
   observeEvent(data(), {
-    initialize(input, session, data, x, exclude, order, multiple, showAll, preselectYear, preselectMinDate)
+    initialize(input, session, data, x, exclude, order, multiple, showAll, preselectYear, preselectMinDate,
+               selectionSets)
   })
 
   observe({
     x$out <- selectdata(data(), input, x$activefilter, xdata, xdataExclude)
   })
 
-  observeEvent(input$filter, if (!showAll) updatefilter(input, x, preselectYear, preselectMinDate))
+  observeEvent(input$filter, if (!showAll) updatefilter(input, x, preselectYear, preselectMinDate, selectionSets))
 
   output$observations <- renderText(paste0(dim(x$out$x)[1], " observations"))
 

--- a/R/modFilter.R
+++ b/R/modFilter.R
@@ -43,6 +43,9 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
   x$initialized <- FALSE
   x$activefilter <- NULL
 
+  # The following two functions implement the logic to convert between a list of raw choices
+  # and an augmented list that includes raw choices and selection sets.
+
   # Build grouped choices for selectize dropdown, adding selection sets as an optgroup
   augmentChoices <- function(choices, filter, selectionSets) {
     sets <- selectionSets[[filter]]
@@ -51,10 +54,11 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
     validSets <- Filter(function(members) all(members %in% choices), sets)
     if (length(validSets) == 0) return(choices)
     setChoices <- stats::setNames(paste0("__SET__", names(validSets)), names(validSets))
-    structure(list(Values = choices, "Selection Sets" = setChoices), class = "list")
+    return(list(Values = choices, "Selection Sets" = setChoices))
   }
 
-  # Expand __SET__ entries in a selection to their member values
+  # When a selection set was selected, expand __SET__ entries in a selection to their
+  # member values
   expandSets <- function(selected, filter, selectionSets) {
     sets <- selectionSets[[filter]]
     if (is.null(sets) || is.null(selected)) return(selected)
@@ -62,7 +66,7 @@ modFilter <- function(input, # nolint: cyclocomp_linter.
     if (!any(isSet)) return(selected)
     setNames <- sub("^__SET__", "", selected[isSet])
     expanded <- unlist(sets[setNames], use.names = FALSE)
-    unique(c(selected[!isSet], expanded))
+    return(unique(c(selected[!isSet], expanded)))
   }
 
   selectdata <- function(data, input, filter, xdata, xdataExclude) {

--- a/R/modLinePlot.R
+++ b/R/modLinePlot.R
@@ -5,13 +5,16 @@
 #' @param input,output,session Default input, output and session objects coming from shiny
 #' @param report A reactive containing the report to be visualized
 #' @param validation A reactive containing validation data to be shown
+#' @param selectionSets named list of selection sets per filter column (passed to \code{\link{modFilter}}).
+#' Defaults to the \code{selectionSets} entry of the active \code{appResults} option.
 #' @author Florian Humpenoeder, Jan Philipp Dietrich
 #' @seealso \code{\link{modLinePlotUI}}, \code{\link{appResults}}
 #' @importFrom ggplot2 ggplot theme_void annotate
 #' @importFrom shiny renderCachedPlot observeEvent updateSelectInput
 #' @export
 
-modLinePlot <- function(input, output, session, report, validation) {
+modLinePlot <- function(input, output, session, report, validation,
+                       selectionSets = getOption("appResults")[[1]]$selectionSets) {
 
   # Quick variable selection handler
   observeEvent(input$quick_select, {
@@ -22,7 +25,7 @@ modLinePlot <- function(input, output, session, report, validation) {
   }, ignoreInit = TRUE)
 
   reduceVariables <- function(x) {
-    if(!is.null(levels(x$variable))) levels(x$variable) <- gsub("\\|\\++\\|","|",levels(x$variable))
+  if(!is.null(levels(x$variable))) levels(x$variable) <- gsub("\\|\\++\\|","|",levels(x$variable))
     return(x)
   }
   
@@ -34,8 +37,8 @@ modLinePlot <- function(input, output, session, report, validation) {
                           xdata        = list(validation=validation()),
                           xdataExclude = c("scenario","period"),
                           order        = c("variable"),
-                          name         = sub("-$","",session$ns('')))
-                        
+                          name         = sub("-$","",session$ns('')),
+                          selectionSets = selectionSets)
 
   lineplot <- reactive({
     start <- Sys.time()

--- a/R/modLinePlot.R
+++ b/R/modLinePlot.R
@@ -14,7 +14,7 @@
 #' @export
 
 modLinePlot <- function(input, output, session, report, validation,
-                       selectionSets = getOption("appResults")[[1]]$selectionSets) {
+                        selectionSets = getOption("appResults")[[1]]$selectionSets) {
 
   # Quick variable selection handler
   observeEvent(input$quick_select, {
@@ -25,10 +25,10 @@ modLinePlot <- function(input, output, session, report, validation,
   }, ignoreInit = TRUE)
 
   reduceVariables <- function(x) {
-  if(!is.null(levels(x$variable))) levels(x$variable) <- gsub("\\|\\++\\|","|",levels(x$variable))
+    if(!is.null(levels(x$variable))) levels(x$variable) <- gsub("\\|\\++\\|","|",levels(x$variable))
     return(x)
   }
-  
+
   selection <- callModule(modFilter, "runfilter",
                           data         = report$report,
                           exclude      = c("value","unit"), 
@@ -115,7 +115,7 @@ modLinePlot <- function(input, output, session, report, validation,
     message("done! (",round(as.numeric(Sys.time()-start,units="secs"),2),"s)")
     return(p)
   })
-  
+
   baseFilename <- reactive({
     sub("_+$", "", gsub("\\.+", "_", make.names(selection()$x$variable[1])))
   })
@@ -123,5 +123,5 @@ modLinePlot <- function(input, output, session, report, validation,
 
   return(renderCachedPlot(lineplot(), res = 120,
                           cacheKeyExpr = { list(selection(), input$show_hist, input$show_proj, input$free_y, input$auto_y, input$legend_right) }))
-  
+
 }

--- a/R/modLinePlot.R
+++ b/R/modLinePlot.R
@@ -116,39 +116,11 @@ modLinePlot <- function(input, output, session, report, validation,
     return(p)
   })
   
-  createFilename <- function(variable,ending) {
-    out <- sub("_+$","",gsub("\\.+","_",make.names(variable[1])))
-    out <- paste0(out,".",ending)
-    return(out)
-  }
-  
-  output$downloadPlotPDF <- downloadHandler(
-    filename = reactive(createFilename(selection()$x$variable,"pdf")),
-    content = function(file) {
-      ggsave(file, plot = lineplot(), device = "pdf",scale=1,width=20,height=18,units="cm",dpi=150)
-    }
-  )
-  output$downloadPlotPNG <- downloadHandler(
-    filename = reactive(createFilename(selection()$x$variable,"png")),
-    content = function(file) {
-      ggsave(file, plot = lineplot(), device = "png",scale=1,width=20,height=18,units="cm",dpi=150)
-    }
-  )
-  
-  output$downloadPlotEPS <- downloadHandler(
-    filename = reactive(createFilename(selection()$x$variable,"eps")),
-    content = function(file) {
-      ggsave(file, plot = lineplot(), device = "eps",scale=1,width=20,height=18,units="cm",dpi=150)
-    }
-  )
-  
-  output$downloadPlotRDS <- downloadHandler(
-    filename = reactive(createFilename(selection()$x$variable,"rds")),
-    content = function(file) {
-      saveRDS(lineplot(),file=file)
-    }
-  )
-  
+  baseFilename <- reactive({
+    sub("_+$", "", gsub("\\.+", "_", make.names(selection()$x$variable[1])))
+  })
+  plotDownloadHandlers(output, lineplot, baseFilename)
+
   return(renderCachedPlot(lineplot(), res = 120,
                           cacheKeyExpr = { list(selection(), input$show_hist, input$show_proj, input$free_y, input$auto_y, input$legend_right) }))
   

--- a/R/plotDownloadHandlers.R
+++ b/R/plotDownloadHandlers.R
@@ -1,0 +1,34 @@
+#' Set up plot download handlers
+#'
+#' Internal utility to create download handlers for PDF, PNG, EPS, and RDS
+#' formats on a Shiny module output. Used by \code{\link{modLinePlot}} and
+#' \code{\link{modAreaPlot}} to avoid code duplication.
+#'
+#' @param output Shiny output object from the module server
+#' @param plotReactive A reactive expression returning the ggplot object
+#' @param baseFilenameReactive A reactive expression returning the base filename (without extension)
+#' @importFrom ggplot2 ggsave
+#' @noRd
+plotDownloadHandlers <- function(output, plotReactive, baseFilenameReactive) {
+
+  makeGgsaveHandler <- function(format) {
+    downloadHandler(
+      filename = reactive(paste0(baseFilenameReactive(), ".", format)),
+      content = function(file) {
+        ggsave(file, plot = plotReactive(), device = format,
+               scale = 1, width = 20, height = 18, units = "cm", dpi = 150)
+      }
+    )
+  }
+
+  output$downloadPlotPDF <- makeGgsaveHandler("pdf")
+  output$downloadPlotPNG <- makeGgsaveHandler("png")
+  output$downloadPlotEPS <- makeGgsaveHandler("eps")
+
+  output$downloadPlotRDS <- downloadHandler(
+    filename = reactive(paste0(baseFilenameReactive(), ".rds")),
+    content = function(file) {
+      saveRDS(plotReactive(), file = file)
+    }
+  )
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A collection of shiny apps and modules to visualize/handle model results
 
-R package **shinyresults**, version **0.35.0**
+R package **shinyresults**, version **0.36.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/shinyresults)](https://cran.r-project.org/package=shinyresults) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1478922.svg)](https://doi.org/10.5281/zenodo.1478922) [![R build status](https://github.com/pik-piam/shinyresults/workflows/check/badge.svg)](https://github.com/pik-piam/shinyresults/actions) [![codecov](https://codecov.io/gh/pik-piam/shinyresults/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/shinyresults) [![r-universe](https://pik-piam.r-universe.dev/badges/shinyresults)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **shinyresults** in publications use:
 
-Dietrich J, Humpenoeder F, Sauer P (2026). "shinyresults: A collection of shiny apps and modules to visualize/handle model results." doi:10.5281/zenodo.1478922 <https://doi.org/10.5281/zenodo.1478922>, Version: 0.35.0, <https://github.com/pik-piam/shinyresults>.
+Dietrich J, Humpenoeder F, Sauer P (2026). "shinyresults: A collection of shiny apps and modules to visualize/handle model results." doi:10.5281/zenodo.1478922 <https://doi.org/10.5281/zenodo.1478922>, Version: 0.36.0, <https://github.com/pik-piam/shinyresults>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,9 +49,9 @@ A BibTeX entry for LaTeX users is
     results},
   author = {Jan Philipp Dietrich and Florian Humpenoeder and Pascal Sauer},
   doi = {10.5281/zenodo.1478922},
-  date = {2026-03-19},
+  date = {2026-03-31},
   year = {2026},
   url = {https://github.com/pik-piam/shinyresults},
-  note = {Version: 0.35.0},
+  note = {Version: 0.36.0},
 }
 ```

--- a/man/appResults.Rd
+++ b/man/appResults.Rd
@@ -32,7 +32,10 @@ appResults(
                      files directly in the tool. Can also be a named character vector of
                      multiple validation files.
            username - username to access "file" and "resultsfolder".
-           password - password to access "file" and "resultsfolder".}
+           password - password to access "file" and "resultsfolder".
+           selectionSets - named list of selection sets per filter column.
+                  Each element is a named list mapping set labels to character vectors of values.
+                  Example: \code{list(region = list("All EUR regions" = c("EUC", "EUS", "EUW", "DEU")))}}
 
 \item{readFilePar}{read report data files in parallel (faster) (TRUE) or in sequence (FALSE)}
 

--- a/man/modAreaPlot.Rd
+++ b/man/modAreaPlot.Rd
@@ -4,12 +4,21 @@
 \alias{modAreaPlot}
 \title{modAreaPlot Module}
 \usage{
-modAreaPlot(input, output, session, report)
+modAreaPlot(
+  input,
+  output,
+  session,
+  report,
+  selectionSets = getOption("appResults")[[1]]$selectionSets
+)
 }
 \arguments{
 \item{input, output, session}{Default input, output and session objects coming from shiny}
 
 \item{report}{A reactive containing the report to be visualized}
+
+\item{selectionSets}{named list of selection sets per filter column (passed to \code{\link{modFilter}}).
+Defaults to the \code{selectionSets} entry of the active \code{appResults} option.}
 }
 \description{
 Shiny module which works together with \code{\link{modAreaPlotUI}} to produce an area plot tab

--- a/man/modFilter.Rd
+++ b/man/modFilter.Rd
@@ -17,7 +17,8 @@ modFilter(
   order = NULL,
   name = NULL,
   preselectYear = NULL,
-  preselectMinDate = NULL
+  preselectMinDate = NULL,
+  selectionSets = NULL
 )
 }
 \arguments{
@@ -46,6 +47,11 @@ listed here will be shown after the ones mentioned.}
 \item{preselectYear}{if provided the year filter will be preselected with this value}
 
 \item{preselectMinDate}{if provided the date filter will be preselected with this as lower value}
+
+\item{selectionSets}{named list of selection sets per filter column. Each element is a named list
+mapping set labels to character vectors of values. When a set is selected, all its member values
+are added to the selection. Only sets where all members are present in the data are shown.
+Example: \code{list(region = list("All EUR regions" = c("EUC", "EUS", "EUW", "DEU")))}}
 }
 \value{
 a reactive list with x as the filtered data and xdata containing the list of additional,

--- a/man/modLinePlot.Rd
+++ b/man/modLinePlot.Rd
@@ -4,7 +4,14 @@
 \alias{modLinePlot}
 \title{modLinePlot Module}
 \usage{
-modLinePlot(input, output, session, report, validation)
+modLinePlot(
+  input,
+  output,
+  session,
+  report,
+  validation,
+  selectionSets = getOption("appResults")[[1]]$selectionSets
+)
 }
 \arguments{
 \item{input, output, session}{Default input, output and session objects coming from shiny}
@@ -12,6 +19,9 @@ modLinePlot(input, output, session, report, validation)
 \item{report}{A reactive containing the report to be visualized}
 
 \item{validation}{A reactive containing validation data to be shown}
+
+\item{selectionSets}{named list of selection sets per filter column (passed to \code{\link{modFilter}}).
+Defaults to the \code{selectionSets} entry of the active \code{appResults} option.}
 }
 \description{
 Shiny module which works together with \code{\link{modLinePlotUI}} to produce a line plot tab


### PR DESCRIPTION
This PR adds that one can select multiple regions at once.

The feature is implemented as a general addition to modFilter, which now supports the concept of "selectionSets". A selection set is available when all items in the set are available for a report. Then, one can select the selectionSet and all items are added at once. 

The selection sets can be configured via the appResults option.

This PR also includes a minor refactoring of the buttons for downloading figures, as they were duplicated between the line and are plot functions.